### PR TITLE
Add Mac Catalyst Target

### DIFF
--- a/DeveloperSettings.xcconfig
+++ b/DeveloperSettings.xcconfig
@@ -1,0 +1,3 @@
+// Developer-specific settings — do not commit changes to source control.
+DEVELOPMENT_TEAM = V2F5S52T3Q
+PRODUCT_BUNDLE_IDENTIFIER = com.oddforms.dongled

--- a/Dongled.xcodeproj/project.pbxproj
+++ b/Dongled.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2934F75C2F82D8C40059798C /* DeveloperSettings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DeveloperSettings.xcconfig; sourceTree = "<group>"; };
 		3B34E4712ECCD51A00F4BA68 /* LaunchIconV138.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = LaunchIconV138.png; sourceTree = "<group>"; };
 		3B34E4762ECCDB9D00F4BA68 /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/Localizable.strings; sourceTree = "<group>"; };
 		3B34E4782ECCDBDC00F4BA68 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
@@ -73,6 +74,7 @@
 		3B46D2C42AA8E82C00272E45 = {
 			isa = PBXGroup;
 			children = (
+				2934F75C2F82D8C40059798C /* DeveloperSettings.xcconfig */,
 				3B46D2CF2AA8E82C00272E45 /* Dongled */,
 				3BE14B492F6AB4740078F341 /* Dongled.app */,
 			);
@@ -275,7 +277,6 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = V2F5S52T3Q;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -341,7 +342,6 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = V2F5S52T3Q;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
@@ -366,6 +366,7 @@
 		};
 		3B46D2F82AA8E82D00272E45 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2934F75C2F82D8C40059798C /* DeveloperSettings.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -373,13 +374,21 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 33;
 				ENABLE_APP_SANDBOX = YES;
-				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = NO;
 				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = YES;
+				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
 				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
+				ENABLE_RESOURCE_ACCESS_USB = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Dongled/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Required to Access External Video Devices";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Required to Access External Audio Devices";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -391,11 +400,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.4.5;
-				PRODUCT_BUNDLE_IDENTIFIER = com.oddforms.dongled;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
@@ -405,22 +413,29 @@
 		};
 		3B46D2F92AA8E82D00272E45 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2934F75C2F82D8C40059798C /* DeveloperSettings.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = Dongled/Dongled.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 33;
-				DEVELOPMENT_TEAM = V2F5S52T3Q;
 				ENABLE_APP_SANDBOX = YES;
-				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
+				ENABLE_INCOMING_NETWORK_CONNECTIONS = NO;
+				ENABLE_OUTGOING_NETWORK_CONNECTIONS = NO;
 				ENABLE_RESOURCE_ACCESS_AUDIO_INPUT = YES;
+				ENABLE_RESOURCE_ACCESS_BLUETOOTH = NO;
+				ENABLE_RESOURCE_ACCESS_CALENDARS = NO;
 				ENABLE_RESOURCE_ACCESS_CAMERA = YES;
+				ENABLE_RESOURCE_ACCESS_CONTACTS = NO;
+				ENABLE_RESOURCE_ACCESS_LOCATION = NO;
+				ENABLE_RESOURCE_ACCESS_PRINTING = NO;
+				ENABLE_RESOURCE_ACCESS_USB = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Dongled/Info.plist;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_NSCameraUsageDescription = "Required to Access External Video Devices";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Required to Access External Audio Devices";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
@@ -432,12 +447,10 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.4.5;
-				PRODUCT_BUNDLE_IDENTIFIER = com.oddforms.dongled;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES;
+				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;

--- a/Dongled/AudioManager.swift
+++ b/Dongled/AudioManager.swift
@@ -76,6 +76,19 @@ final class AudioManager: NSObject {
             do {
                 try engine.start()
                 print("AudioEngine started → Session Running")
+
+                /// Diagnostic: where is audio actually routed?
+                let route = session.currentRoute
+                print("Audio route inputs:")
+                for input in route.inputs {
+                    print("  ← \(input.portName) [type: \(input.portType.rawValue), UID: \(input.uid)]")
+                }
+                print("Audio route outputs:")
+                for output in route.outputs {
+                    print("  → \(output.portName) [type: \(output.portType.rawValue), UID: \(output.uid)]")
+                }
+                print("Output volume: \(engine.mainMixerNode.outputVolume)")
+                print("Input node volume: \(inputNode.volume)")
             } catch {
                 print("Failed to start AVAudioEngine: \(error)")
             }

--- a/Dongled/CaptureManager.swift
+++ b/Dongled/CaptureManager.swift
@@ -138,6 +138,13 @@ final class CaptureManager: NSObject {
             guard let self = self else { return }
             let session = AVCaptureSession()
             session.beginConfiguration()
+
+            if self.isRunningOnMac() {
+                /// Use `.inputPriority` so the session defers to the device's activeFormat
+                /// instead of clamping to the default `.high` preset (typically ≤1080p)
+                session.sessionPreset = .inputPriority
+            }
+
             do {
                 let input = try AVCaptureDeviceInput(device: device)
                 if session.canAddInput(input) {
@@ -147,11 +154,99 @@ final class CaptureManager: NSObject {
             } catch {
                 print("Failed to add device input: \(error)")
             }
+
+            /// An iPad typically has more constrained USB bandwidth and processing power
+            /// than a Mac, so the safe behavior of the session is to use the default/implicit `.high` preset.
+            /// Selecting 4k60 on an older iPad could choke the USB bus or drop frames.
+            if self.isRunningOnMac() {
+                self.selectBestFormat(for: device)
+            }
+
             session.commitConfiguration()
 
             self.captureSession = session
             self.startSession()
             self.audioManager.startEngineInputPassThrough()
+        }
+    }
+
+    /// Selects the best format by pixel throughput (width × height × fps).
+    /// For example, this approach favors 3840×2160@60 over 3840×2880@30.
+    private func selectBestFormat(for device: AVCaptureDevice) {
+        let formats = device.formats
+
+        var bestFormat: AVCaptureDevice.Format?
+        var bestWidth: Int32 = 0
+        var bestHeight: Int32 = 0
+        var bestFrameRate: Float64 = 0
+        var bestScore: Float64 = 0
+
+        for format in formats {
+            let desc = format.formatDescription
+            let dimensions = CMVideoFormatDescriptionGetDimensions(desc)
+            let width = dimensions.width
+            let height = dimensions.height
+            let mediaSubType = CMFormatDescriptionGetMediaSubType(desc)
+            let fourCC = String(format: "%c%c%c%c",
+                                (mediaSubType >> 24) & 0xFF,
+                                (mediaSubType >> 16) & 0xFF,
+                                (mediaSubType >> 8) & 0xFF,
+                                mediaSubType & 0xFF)
+
+            let maxRate = format.videoSupportedFrameRateRanges
+                .map { $0.maxFrameRate }
+                .max() ?? 0
+
+            let score = Float64(width) * Float64(height) * maxRate
+
+            print("  Format: \(width)×\(height) @ \(maxRate) fps [\(fourCC)]")
+
+            if score > bestScore {
+                bestFormat = format
+                bestWidth = width
+                bestHeight = height
+                bestFrameRate = maxRate
+                bestScore = score
+            }
+        }
+
+        guard let selectedFormat = bestFormat else {
+            print("No suitable format found. Using device default.")
+            return
+        }
+
+        do {
+            try device.lockForConfiguration()
+            device.activeFormat = selectedFormat
+            /// Set the frame duration to match the best frame rate
+            if bestFrameRate > 0 {
+                device.activeVideoMinFrameDuration = CMTime(value: 1, timescale: CMTimeScale(bestFrameRate))
+                device.activeVideoMaxFrameDuration = CMTime(value: 1, timescale: CMTimeScale(bestFrameRate))
+            }
+            device.unlockForConfiguration()
+            print("Selected format: \(bestWidth)×\(bestHeight) @ \(bestFrameRate) fps")
+        } catch {
+            print("Failed to set device format: \(error)")
+        }
+    }
+
+    private func selectDevice(_ device: AVCaptureDevice) {
+        currentDevicePicker = nil
+        updateState(.connecting)
+        sessionQueue.asyncAfter(deadline: .now() + 2.2) {
+            let nowDevices = AVCaptureDevice.DiscoverySession(
+                deviceTypes: [.external],
+                mediaType: .video,
+                position: .unspecified
+            ).devices
+            guard nowDevices.contains(where: { $0.uniqueID == device.uniqueID }) else {
+                print("Device Removed. Aborting...")
+                DispatchQueue.main.async {
+                    self.updateState(.scanning)
+                }
+                return
+            }
+            self.configureSession(with: device)
         }
     }
 
@@ -163,6 +258,7 @@ final class CaptureManager: NSObject {
         let layer = AVCaptureVideoPreviewLayer(session: session)
         previewLayer = layer
         layer.frame = view.bounds
+        layer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]  // ensure the layer auto-resizes with the parent view.
         layer.videoGravity = .resizeAspect
         view.layer.insertSublayer(layer, at: 0)
         print("Starting Video Preview Layer.")
@@ -217,6 +313,14 @@ final class CaptureManager: NSObject {
             return
         }
 
+        /// If there there is only one device, there is only one choice.  Auto-select!
+        if uniqueDevices.count == 1,
+           let autoSelectedDevice = uniqueDevices.first {
+            print("Auto-selecting device! Booting…")
+            selectDevice(autoSelectedDevice)
+            return
+        }
+
         let presentPicker: () -> Void = { [weak self, weak viewController] in
             guard let self = self, let viewController = viewController else { return }
             let alert = UIAlertController(
@@ -228,21 +332,7 @@ final class CaptureManager: NSObject {
             for uniqueDevice in uniqueDevices {
                 let action = UIAlertAction(title: uniqueDevice.localizedName, style: .default) { [weak self] _ in
                     print("Device Selected! Booting…")
-                    self?.currentDevicePicker = nil
-                    self?.updateState(.connecting)
-                    self?.sessionQueue.asyncAfter(deadline: .now() + 2.2) {
-                        let nowDevices = AVCaptureDevice.DiscoverySession(
-                            deviceTypes: [.external],
-                            mediaType: .video,
-                            position: .unspecified
-                        ).devices
-                        guard nowDevices.contains(where: { $0.uniqueID == uniqueDevice.uniqueID }) else {
-                            print("Device Removed. Aborting...")
-                            DispatchQueue.main.async { self?.updateState(.scanning) }
-                            return
-                        }
-                        self?.configureSession(with: uniqueDevice)
-                    }
+                    self?.selectDevice(uniqueDevice)
                 }
                 alert.addAction(action)
             }

--- a/Dongled/CaptureManager.swift
+++ b/Dongled/CaptureManager.swift
@@ -258,7 +258,9 @@ final class CaptureManager: NSObject {
         let layer = AVCaptureVideoPreviewLayer(session: session)
         previewLayer = layer
         layer.frame = view.bounds
+        #if targetEnvironment(macCatalyst)
         layer.autoresizingMask = [.layerWidthSizable, .layerHeightSizable]  // ensure the layer auto-resizes with the parent view.
+        #endif
         layer.videoGravity = .resizeAspect
         view.layer.insertSublayer(layer, at: 0)
         print("Starting Video Preview Layer.")

--- a/Dongled/Dongled.entitlements
+++ b/Dongled/Dongled.entitlements
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>aps-environment</key>
-	<string>production</string>
-</dict>
+<dict/>
 </plist>

--- a/Dongled/Info.plist
+++ b/Dongled/Info.plist
@@ -5,9 +5,9 @@
 	<key>UISupportsTrueScreenSizeOnMac</key>
 	<true/>
 	<key>NSMicrophoneUsageDescription</key>
-	<string>Required for external audio input monitoring</string>
+	<string>Required to Access External Audio Devices</string>
 	<key>NSCameraUsageDescription</key>
-	<string>Required for external video input monitoring</string>
+	<string>Required to Access External Video Devices</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleLocalizations</key>

--- a/Dongled/Info.plist
+++ b/Dongled/Info.plist
@@ -21,6 +21,8 @@
 		<string>ar</string>
 		<string>th</string>
 	</array>
+	<key>NSCameraUseExternalDeviceType</key>
+	<true/>
 	<key>UIApplicationSceneManifest</key>
 	<dict>
 		<key>UIApplicationSupportsMultipleScenes</key>


### PR DESCRIPTION
This PR adds a Mac Catalyst target to the project, removing the iPad-on-Mac target and making appropriate changes to the codebase in support of Catalyst.

These changes include:
- A modest improvement to the Mac-side where it selects the best format by pixel throughput (width × height × fps). For example, this approach favors 3840×2160@60 over 3840×2880@30. 
- On Mac, configure the preview layer to auto-resize when the parent view resizes.
- On Mac, I added some diagnostics to report what video formats are supported by the available devices.
- Ensure that the Info.plist opts into `AVCaptureDeviceTypeExternal` so that all your existing `AVCaptureDevice.DeviceType.external` use behaves as expected on Mac Catalyst.

To the project itself, I made the following changes:
- Added some diagnostics to see where the audio is actually routed.
- Added support for a `DeveloperSettings.xcconfig`, so that other developers can locally override the Xcode settings for code signing and not encounter build errors.  The contributed file is configured for @oddforms-design, by default.  I didn't add a `.gitignore` entry so that it would remain undisturbed/tracked, but I think that may be a good improvement.
- Codified keys used for the camera and microphone permission requests.

## Testing Considerations

I've tested on my iPad Pro (M1) running iPadOS 26.4 and my M4 Mac mini on Tahoe 26.4, with a Genki ShadowCast 3 connected.
- On iPad: I evaluated device rotation, resized the window in Windowed Apps-mode, validated (dis|re)connect, background restoration, and user-declined permissions.
- On Mac: I evaluated window size changes, validated (dis|re)connect, background restoration, and user-declined permissions.

## Before

## No device connected
<img width="2083" height="1252" alt="Screenshot 2026-04-05 at 2 09 39 PM" src="https://github.com/user-attachments/assets/a26cdeda-b7cf-4b9b-a166-7bf526848a74" />

### ShadowCast 3 use
<img width="640" height="385" alt="573871087-aac8a74f-32a7-45bb-83f6-15772a6c4642" src="https://github.com/user-attachments/assets/609fbc9a-1879-4734-a52e-4e403fcb8890" />

## After

### No device connected

<img width="1872" height="1103" alt="Screenshot 2026-04-05 at 2 07 51 PM" src="https://github.com/user-attachments/assets/75db5b9f-2d40-4f9e-81c5-f10d056d5e84" />

### ShadowCast 3 use
<img width="640" height="377" alt="573871667-dcd8bcdb-445e-45a3-be5e-dfe8d8e0cbca" src="https://github.com/user-attachments/assets/e902853e-3d69-4c67-87ab-5a8edb42de37" />