### PR TITLE
Auto-hide Window Chrome on Mac Catalyst

### DIFF
--- a/Dongled/CaptureManager.swift
+++ b/Dongled/CaptureManager.swift
@@ -16,7 +16,7 @@ protocol CaptureManagerDelegate: AnyObject {
 final class CaptureManager: NSObject {
     /// UI States
     enum State {
-        case scanning, connecting, active
+        case scanning, connecting, active(_ connectedDeviceIDs: [String])
     }
 
     // MARK: - Properties
@@ -406,7 +406,7 @@ final class CaptureManager: NSObject {
                 return
             }
             session.startRunning()
-            DispatchQueue.main.async { self.updateState(.active) }
+            DispatchQueue.main.async { self.updateState(.active(connectedInputIDs)) }
         }
     }
 

--- a/Dongled/ViewController.swift
+++ b/Dongled/ViewController.swift
@@ -29,6 +29,13 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
     private var trackedDeviceIDs = Set<String>()
     private var needsSessionRestart = false
     
+    #if targetEnvironment(macCatalyst)
+    // MARK: - Properties (Cursor Auto-Hide - Mac Catalyst)
+    private var cursorHideTimer: Timer?
+    private var isCursorHidden = false
+    private let cursorHideDelay: TimeInterval = 3.0
+    #endif
+    
     override var prefersHomeIndicatorAutoHidden: Bool { true }
     override var prefersStatusBarHidden: Bool { isStatusBarHidden }
     
@@ -47,6 +54,10 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
         captureManager.delegate = self
         view.backgroundColor = .black
         registerNotifications()
+        
+        #if targetEnvironment(macCatalyst)
+        setupCursorAutoHide()
+        #endif
     }
     
     // MARK: - Notification Registration
@@ -163,6 +174,10 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
                 self.coverView.isHidden = false
                 self.noDeviceLabel.isHidden = false
                 
+                #if targetEnvironment(macCatalyst)
+                self.cancelCursorHideTimer()
+                #endif
+                
                 let camStatus = AVCaptureDevice.authorizationStatus(for: .video)
                 let micStatus = AVCaptureDevice.authorizationStatus(for: .audio)
                 
@@ -185,12 +200,20 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
                 self.noDeviceLabel.text = StatusText.connecting
                 self.activityIndicator.isHidden = false
                 
+                #if targetEnvironment(macCatalyst)
+                self.cancelCursorHideTimer()
+                #endif
+                
             case .active:
                 self.isStatusBarHidden = true
                 UIApplication.shared.isIdleTimerDisabled = true
                 self.coverView.isHidden = true
                 self.noDeviceLabel.isHidden = true
                 self.activityIndicator.isHidden = true
+                
+                #if targetEnvironment(macCatalyst)
+                self.resetCursorHideTimer()
+                #endif
             }
         }
     }
@@ -219,3 +242,61 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
         NotificationCenter.default.removeObserver(self)
     }
 }
+
+// MARK: - UIPointerInteractionDelegate (Cursor Auto-Hide - Mac Catalyst)
+
+#if targetEnvironment(macCatalyst)
+extension ViewController: UIPointerInteractionDelegate {
+    
+    fileprivate func setupCursorAutoHide() {
+        let hover = UIHoverGestureRecognizer(target: self, action: #selector(handleHover(_:)))
+        view.addGestureRecognizer(hover)
+        
+        let pointerInteraction = UIPointerInteraction(delegate: self)
+        view.addInteraction(pointerInteraction)
+    }
+    
+    @objc private func handleHover(_ recognizer: UIHoverGestureRecognizer) {
+        switch recognizer.state {
+        case .changed:
+            showCursor()
+            resetCursorHideTimer()
+        default:
+            break
+        }
+    }
+    
+    fileprivate func resetCursorHideTimer() {
+        cursorHideTimer?.invalidate()
+        cursorHideTimer = Timer.scheduledTimer(withTimeInterval: cursorHideDelay, repeats: false) { [weak self] _ in
+            self?.hideCursor()
+        }
+    }
+    
+    fileprivate func cancelCursorHideTimer() {
+        cursorHideTimer?.invalidate()
+        cursorHideTimer = nil
+        showCursor()
+    }
+    
+    private func hideCursor() {
+        guard !isCursorHidden else { return }
+        isCursorHidden = true
+        view.interactions
+            .compactMap { $0 as? UIPointerInteraction }
+            .forEach { $0.invalidate() }
+    }
+    
+    private func showCursor() {
+        guard isCursorHidden else { return }
+        isCursorHidden = false
+        view.interactions
+            .compactMap { $0 as? UIPointerInteraction }
+            .forEach { $0.invalidate() }
+    }
+    
+    func pointerInteraction(_ interaction: UIPointerInteraction, styleFor region: UIPointerRegion) -> UIPointerStyle? {
+        return isCursorHidden ? .hidden() : nil
+    }
+}
+#endif

--- a/Dongled/ViewController.swift
+++ b/Dongled/ViewController.swift
@@ -81,6 +81,10 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
         let hasValidSession = captureManager.hasValidSession
         if needsSessionRestart {
             print("Forcing capture restart after background suspension.")
+#if targetEnvironment(macCatalyst)
+            showChrome(forceTitlebarVisible: true)
+            resetCursorHideTimer()
+#endif
             needsSessionRestart = false
             captureManager.authorizeCapture(from: self)
         } else if case .scanning = captureManager.state {
@@ -313,7 +317,18 @@ extension ViewController: UIPointerInteractionDelegate {
         setTitlebarHidden(true)
     }
 
-    private func showChrome() {
+    private func showChrome(forceTitlebarVisible: Bool = false) {
+        /// NOTE: If the app had hidden its chrome prior to being backgrounded, when the app returns
+        /// to the foreground, UIKit resets its own state — effectively restoring `title​Visibility` to
+        /// `.visible` and invalidates/resets the underlying `UIPointer​Interaction` so the
+        /// cursor reappears. However, the AppKit-level `hidden` property set directly on the
+        /// `NSButton` objects is not reset by the system.  To keep concerns as self-contained as
+        /// possible, allow callers to force our state to be coherent with UIKit.
+        if forceTitlebarVisible, !isCursorHidden {
+            setTitlebarHidden(false)
+            return
+        }
+
         guard isCursorHidden else { return }
         isCursorHidden = false
         view.interactions

--- a/Dongled/ViewController.swift
+++ b/Dongled/ViewController.swift
@@ -48,16 +48,19 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
     }
     
     // MARK: - Lifecycle
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+#if targetEnvironment(macCatalyst)
+        setupChromeAutoHide()  // Requires a key window in order to perform appearance modifications.
+#endif
+    }
+
     // Initial setup for UI handling
     override func viewDidLoad() {
         super.viewDidLoad()
         captureManager.delegate = self
         view.backgroundColor = .black
         registerNotifications()
-        
-        #if targetEnvironment(macCatalyst)
-        setupChromeAutoHide()
-        #endif
     }
     
     // MARK: - Notification Registration
@@ -262,6 +265,20 @@ extension ViewController: UIPointerInteractionDelegate {
 
         let pointerInteraction = UIPointerInteraction(delegate: self)
         view.addInteraction(pointerInteraction)
+
+        // TASK: Force a dark appearance so title text can remain readable over arbitrary video content.
+
+        guard let nsWindow = sharedKeyWindow else { return }
+
+        if let appearanceClass = NSClassFromString("NSAppearance") as? NSObject.Type {
+            let sel = NSSelectorFromString("appearanceNamed:")
+            let darkAqua = (appearanceClass as AnyObject)
+                .perform(sel, with: "NSAppearanceNameDarkAqua")?
+                .takeUnretainedValue()
+            nsWindow.setValue(darkAqua, forKey: "appearance")
+        } else {
+            print("Unable to force dark appearance.")
+        }
     }
 
     @objc private func handleHover(_ recognizer: UIHoverGestureRecognizer) {
@@ -326,12 +343,9 @@ extension ViewController: UIPointerInteractionDelegate {
         // to accomplish our task.
         // See <https://developer.apple.com/forums/thread/769279>, <https://developer.apple.com/documentation/UIKit/mac-catalyst>.
 
-        guard let nsApp = NSClassFromString("NSApplication"),
-              let sharedApp = nsApp.value(forKeyPath: "sharedApplication") as? NSObject,
-              let nsWindow = sharedApp.value(forKey: "keyWindow") as? NSObject else { return }
-
         let buttonSel = NSSelectorFromString("standardWindowButton:")
-        guard nsWindow.responds(to: buttonSel) else { return }
+        guard let nsWindow = sharedKeyWindow,
+              nsWindow.responds(to: buttonSel) else { return }
 
         typealias ButtonIMP = @convention(c) (NSObject, Selector, Int) -> NSObject?
         let imp = nsWindow.method(for: buttonSel)
@@ -343,6 +357,18 @@ extension ViewController: UIPointerInteractionDelegate {
             if let button = buttonFunc(nsWindow, buttonSel, buttonType) {
                 button.setValue(hidden, forKey: "hidden")
             }
+        }
+    }
+
+    // MARK: - AppKit Helpers
+
+    private var sharedKeyWindow: NSObject? {
+        if let nsApp = NSClassFromString("NSApplication"),
+              let sharedApp = nsApp.value(forKeyPath: "sharedApplication") as? NSObject,
+              let nsWindow = sharedApp.value(forKey: "keyWindow") as? NSObject {
+            nsWindow
+        } else {
+            nil
         }
     }
 }

--- a/Dongled/ViewController.swift
+++ b/Dongled/ViewController.swift
@@ -80,7 +80,9 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
             print("Forcing capture restart after background suspension.")
             needsSessionRestart = false
             captureManager.authorizeCapture(from: self)
-        } else if captureManager.state == .scanning || !hasValidSession {
+        } else if case .scanning = captureManager.state {
+            captureManager.authorizeCapture(from: self)
+        } else if !hasValidSession {
             captureManager.authorizeCapture(from: self)
         } else {
             print("Capture session already active. Skipping re-boot.")
@@ -226,7 +228,11 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
             updateUI(for: .scanning)
         case .connecting:
             updateUI(for: .connecting)
-        case .active:
+        case .active(let connectedDeviceIDs):
+            #if targetEnvironment(macCatalyst)
+            connectedDeviceIDs.forEach { trackedDeviceIDs.update(with: $0) }
+            #endif
+            
             captureManager.attachPreview(to: self.view)
             /// Tiny delay to give the layer time to finish flipping over
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {

--- a/Dongled/ViewController.swift
+++ b/Dongled/ViewController.swift
@@ -30,10 +30,10 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
     private var needsSessionRestart = false
     
     #if targetEnvironment(macCatalyst)
-    // MARK: - Properties (Cursor Auto-Hide - Mac Catalyst)
-    private var cursorHideTimer: Timer?
+    // MARK: - Properties (Chrome Auto-Hide - Mac Catalyst)
+    private var chromeHideTimer: Timer?
     private var isCursorHidden = false
-    private let cursorHideDelay: TimeInterval = 3.0
+    private let chromeHideDelay: TimeInterval = 3.0
     #endif
     
     override var prefersHomeIndicatorAutoHidden: Bool { true }
@@ -56,7 +56,7 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
         registerNotifications()
         
         #if targetEnvironment(macCatalyst)
-        setupCursorAutoHide()
+        setupChromeAutoHide()
         #endif
     }
     
@@ -243,60 +243,101 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
     }
 }
 
-// MARK: - UIPointerInteractionDelegate (Cursor Auto-Hide - Mac Catalyst)
 
 #if targetEnvironment(macCatalyst)
+// MARK: - UIPointerInteractionDelegate (Chrome Auto-Hide - Mac Catalyst)
 extension ViewController: UIPointerInteractionDelegate {
-    
-    fileprivate func setupCursorAutoHide() {
+
+    // MARK: - Chrome Auto-Hide Orchestration
+
+    fileprivate func setupChromeAutoHide() {
         let hover = UIHoverGestureRecognizer(target: self, action: #selector(handleHover(_:)))
         view.addGestureRecognizer(hover)
-        
+
         let pointerInteraction = UIPointerInteraction(delegate: self)
         view.addInteraction(pointerInteraction)
     }
-    
+
     @objc private func handleHover(_ recognizer: UIHoverGestureRecognizer) {
         switch recognizer.state {
         case .changed:
-            showCursor()
+            showChrome()
             resetCursorHideTimer()
         default:
             break
         }
     }
-    
+
     fileprivate func resetCursorHideTimer() {
-        cursorHideTimer?.invalidate()
-        cursorHideTimer = Timer.scheduledTimer(withTimeInterval: cursorHideDelay, repeats: false) { [weak self] _ in
-            self?.hideCursor()
+        chromeHideTimer?.invalidate()
+        chromeHideTimer = Timer.scheduledTimer(withTimeInterval: chromeHideDelay, repeats: false) { [weak self] _ in
+            self?.hideChrome()
         }
     }
-    
+
     fileprivate func cancelCursorHideTimer() {
-        cursorHideTimer?.invalidate()
-        cursorHideTimer = nil
-        showCursor()
+        chromeHideTimer?.invalidate()
+        chromeHideTimer = nil
+        showChrome()
     }
-    
-    private func hideCursor() {
+
+    private func hideChrome() {
         guard !isCursorHidden else { return }
         isCursorHidden = true
         view.interactions
             .compactMap { $0 as? UIPointerInteraction }
             .forEach { $0.invalidate() }
+        setTitlebarHidden(true)
     }
-    
-    private func showCursor() {
+
+    private func showChrome() {
         guard isCursorHidden else { return }
         isCursorHidden = false
         view.interactions
             .compactMap { $0 as? UIPointerInteraction }
             .forEach { $0.invalidate() }
+        setTitlebarHidden(false)
     }
-    
+
+    // MARK: - UIPointerInteractionDelegate
+
     func pointerInteraction(_ interaction: UIPointerInteraction, styleFor region: UIPointerRegion) -> UIPointerStyle? {
         return isCursorHidden ? .hidden() : nil
+    }
+
+    // MARK: - Titlebar Visibility
+
+    private func setTitlebarHidden(_ hidden: Bool) {
+        guard let windowScene = view.window?.windowScene,
+              let titlebar = windowScene.titlebar else { return }
+
+        titlebar.titleVisibility = hidden ? .hidden : .visible
+
+        // TASK: Hide/show standard window buttons (close, minimize, zoom)
+
+        // NOTE: Since Mac Catalyst does not support directly accessing some APIs,
+        // (e.g. `NSWindow`, `NSWindowButton`) we'll need to do dynamic lookup
+        // to accomplish our task.
+        // See <https://developer.apple.com/forums/thread/769279>, <https://developer.apple.com/documentation/UIKit/mac-catalyst>.
+
+        guard let nsApp = NSClassFromString("NSApplication"),
+              let sharedApp = nsApp.value(forKeyPath: "sharedApplication") as? NSObject,
+              let nsWindow = sharedApp.value(forKey: "keyWindow") as? NSObject else { return }
+
+        let buttonSel = NSSelectorFromString("standardWindowButton:")
+        guard nsWindow.responds(to: buttonSel) else { return }
+
+        typealias ButtonIMP = @convention(c) (NSObject, Selector, Int) -> NSObject?
+        let imp = nsWindow.method(for: buttonSel)
+        let buttonFunc = unsafeBitCast(imp, to: ButtonIMP.self)
+
+        /// The value space (0...2) is a set representing the NSWindowButton enumeration:
+        /// (NSWindowCloseButton, NSWindowMiniaturizeButton, NSWindowZoomButton)
+        for buttonType in 0...2 {
+            if let button = buttonFunc(nsWindow, buttonSel, buttonType) {
+                button.setValue(hidden, forKey: "hidden")
+            }
+        }
     }
 }
 #endif


### PR DESCRIPTION
This PR adds support for automatically hiding the main window's title, window controls, and mouse cursor (collectively referred to as chrome) after a 3 second idle period.  When the mouse cursor is moved, the chrome is shown again, resetting the 3 second delay. 

### Additional Changes

This PR fixes an existing issue brought forward from the iPad-on-Mac app: when a session is active for a device that was already connected prior to the launch of the app and then is disconnected later, the session is not torn down.

## Testing Considerations

I've tested on my iPad Pro (M1) running iPadOS 26.4 and my M4 Mac mini on Tahoe 26.4, with a Genki ShadowCast 3 connected.

- On iPad: I've tested that the effort does not affect the iPad target.
- On Mac: I evaluated chrome behavior/restoration in Windowed, Full Screen, during Mission Control and Spaces, appearance changes, and hiding. 

### Before
<img width="1836" height="1082" alt="before" src="https://github.com/user-attachments/assets/b08955fb-0c33-43a1-b155-664725267877" />

### After

#### Chrome Shown
<img width="1836" height="1082" alt="chromeShown" src="https://github.com/user-attachments/assets/ae653822-9c19-416e-a4cc-5c12de2b0f2b" />

#### Chrome Hidden
<img width="1836" height="1082" alt="chromeHidden" src="https://github.com/user-attachments/assets/e70c5c43-d74a-4e6c-946d-24884f1b9327" />
