### PR TITLE
Fix issue of display not reliably sleeping on Mac Catalyst

### DIFF
--- a/Dongled/ViewController.swift
+++ b/Dongled/ViewController.swift
@@ -34,6 +34,10 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
     private var chromeHideTimer: Timer?
     private var isCursorHidden = false
     private let chromeHideDelay: TimeInterval = 3.0
+
+    /// Activity assertion that keeps the display awake while capture is active.
+    /// - Remark: `UIApplication.isIdleTimerDisabled` does not prevent display sleep on Mac Catalyst.
+    private var displayAwakeToken: (any NSObjectProtocol)?
     #endif
     
     override var prefersHomeIndicatorAutoHidden: Bool { true }
@@ -172,14 +176,34 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
     enum UIState {
         case scanning, connecting, active
     }
-    
+
+    /// Keeps the display awake while capture is active.
+    /// On Mac Catalyst `UIApplication.isIdleTimerDisabled` does not block display sleep,
+    /// so hold a `ProcessInfo` activity assertion with `.idleDisplaySleepDisabled` instead.
+    private func setKeepDisplayAwake(_ awake: Bool) {
+#if targetEnvironment(macCatalyst)
+        if awake {
+            guard displayAwakeToken == nil else { return }
+            displayAwakeToken = ProcessInfo.processInfo.beginActivity(
+                options: [.idleDisplaySleepDisabled, .userInitiated],
+                reason: "Capturing video from external device"
+            )
+        } else if let token = displayAwakeToken {
+            ProcessInfo.processInfo.endActivity(token)
+            displayAwakeToken = nil
+        }
+#else
+        UIApplication.shared.isIdleTimerDisabled = awake
+#endif
+    }
+
     // Updates the UI for the given state
     func updateUI(for state: UIState) {
         DispatchQueue.main.async {
             switch state {
             case .scanning:
                 self.isStatusBarHidden = false
-                UIApplication.shared.isIdleTimerDisabled = false
+                self.setKeepDisplayAwake(false)
                 self.coverView.isHidden = false
                 self.noDeviceLabel.isHidden = false
                 
@@ -203,7 +227,7 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
                 
             case .connecting:
                 self.isStatusBarHidden = false
-                UIApplication.shared.isIdleTimerDisabled = false
+                self.setKeepDisplayAwake(false)
                 self.coverView.isHidden = false
                 self.noDeviceLabel.isHidden = false
                 self.noDeviceLabel.text = StatusText.connecting
@@ -215,7 +239,7 @@ final class ViewController: UIViewController, CaptureManagerDelegate {
                 
             case .active:
                 self.isStatusBarHidden = true
-                UIApplication.shared.isIdleTimerDisabled = true
+                self.setKeepDisplayAwake(true)
                 self.coverView.isHidden = true
                 self.noDeviceLabel.isHidden = true
                 self.activityIndicator.isHidden = true


### PR DESCRIPTION
**What does this PR do?**
This PR adds support for an activity assertion on Mac Catalyst, while maintaining the existing behavior on iPad.  

`UIApplication.isIdleTimerDisabled` on Mac Catalyst doesn't reliably prevent display sleep. It was originally designed around iOS auto-lock, and on macOS the display sleep timer is governed by `pmset`/`IOPMAssertion` on the AppKit side.  

**How do you test?**
To verify on the Mac: while Dongled is active, run `pmset -g assertions` in Terminal and you should see a `PreventUserIdleDisplaySleep` (and a `PreventUserIdleSystemSleep`) assertion attributed to Dongled with the "Capturing video from external device" reason. It should disappear within ~0.25s of unplugging the device (and the app's internal state returns to `.scanning`).